### PR TITLE
Beneficiary is obsolet in canClaim

### DIFF
--- a/EIPS/eip-earnings.md
+++ b/EIPS/eip-earnings.md
@@ -46,10 +46,9 @@ interface EarningsOnClaim {
      * Looks if claiming earnings is currently possible for a claimer and a beneficiary. 
      * For example the claimer might not have performed KYC and is not entitled to claim the returns 
      * @param _claimer the asset owner for the returns, can be `msg.sender`
-     * @param _beneficiary the destination for the returns, can be `msg.sender` or same as _claimer
      * @return _returnCode, normally `0` if everything went well.
      **/
-    function canClaim(address _claimer, address _beneficiary)
+    function canClaim(address _claimer)
     public
     returns (uint256 _returnCode);
 


### PR DESCRIPTION
Earnings can be distributed to a address in a second step. 
Therefore it does simply not make any sense to ask if the beneficiary is allowed to be the destination of this proces

When opening a pull request to submit a new EIP, please use the suggested template: https://github.com/ethereum/EIPs/blob/master/eip-X.md

We have a GitHub bot that automatically merges some PRs. It will merge yours immediately if certain criteria are met:

 - The PR edits only existing draft PRs.
 - The build passes.
 - Your Github username or email address is listed in the 'author' header of all affected PRs, inside <triangular brackets>.
 - If matching on email address, the email address is the one publicly listed on your GitHub profile.
